### PR TITLE
Fix Dompdf class reference

### DIFF
--- a/certificate-manager/certificate-manager.php
+++ b/certificate-manager/certificate-manager.php
@@ -186,10 +186,10 @@ class CM_Certificate_Manager {
     }
 
     private function generate_pdf( $first, $last, $position, $course, $code ) {
-        if ( ! class_exists( '\\Dompdf\\Dompdf' ) ) {
+        if ( ! class_exists( '\Dompdf\Dompdf' ) ) {
             return false;
         }
-        $dompdf = new Dompdf\\Dompdf();
+        $dompdf = new \Dompdf\Dompdf();
         ob_start();
         include plugin_dir_path( __FILE__ ) . 'templates/certificate-template.php';
         $html = ob_get_clean();


### PR DESCRIPTION
## Summary
- correct class name check when generating PDFs
- instantiate Dompdf using FQCN

## Testing
- `php -l certificate-manager/certificate-manager.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fde2ee60832abb5244e55f73555e