### PR TITLE
Add image background option for certificates

### DIFF
--- a/certificate-manager/templates/certificate-template.php
+++ b/certificate-manager/templates/certificate-template.php
@@ -3,16 +3,29 @@
 <head>
     <meta charset="utf-8">
     <style>
-        body { font-family: DejaVu Sans, sans-serif; text-align:center; }
-        h1 { font-size:32px; }
-        p { font-size:20px; }
+        body { margin:0; padding:0; font-family: DejaVu Sans, sans-serif; }
+        #certificate { position:relative; width:100%; height:100%; }
+        #certificate img { width:100%; height:auto; display:block; }
+        .field { position:absolute; font-size:20px; }
     </style>
 </head>
 <body>
-    <h1>Certificado</h1>
-    <p>Otorgado a <strong><?php echo esc_html( $first . ' ' . $last ); ?></strong></p>
-    <p>Por su participación como <strong><?php echo esc_html( $position ); ?></strong></p>
-    <p>En el curso <strong><?php echo esc_html( $course ); ?></strong></p>
-    <p>Código: <strong><?php echo esc_html( $code ); ?></strong></p>
+    <div id="certificate">
+        <?php if ( $bg_image ) : ?>
+            <img src="<?php echo esc_url( $bg_image ); ?>" alt="Background" />
+        <?php endif; ?>
+        <div class="field" style="top:<?php echo intval( $name_y ); ?>px; left:<?php echo intval( $name_x ); ?>px;">
+            <?php echo esc_html( $first . ' ' . $last ); ?>
+        </div>
+        <div class="field" style="top:<?php echo intval( $position_y ); ?>px; left:<?php echo intval( $position_x ); ?>px;">
+            <?php echo esc_html( $position ); ?>
+        </div>
+        <div class="field" style="top:<?php echo intval( $course_y ); ?>px; left:<?php echo intval( $course_x ); ?>px;">
+            <?php echo esc_html( $course ); ?>
+        </div>
+        <div class="field" style="top:<?php echo intval( $code_y ); ?>px; left:<?php echo intval( $code_x ); ?>px;">
+            <?php echo esc_html( $code ); ?>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow admins to upload a background image and set field coordinates
- generate PDFs using that custom layout

## Testing
- `php -l certificate-manager/certificate-manager.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ffe4ef04832ab4c6a9d18581a456